### PR TITLE
Section process rework

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -140,7 +140,10 @@ disable=print-statement,
         exception-escape,
         comprehension-escape,
         too-few-public-methods,
-        redefined-builtin
+        redefined-builtin,
+        line-too-long,
+        anomalous-backslash-in-string,
+        not-async-context-manager
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/slurry/sections/_buffers.py
+++ b/slurry/sections/_buffers.py
@@ -58,7 +58,7 @@ class Window(Section):
                 while len(buf) > self.max_size or now - buf[0][1] > self.max_age:
                     buf.popleft()
                 if len(buf) >= self.min_size:
-                    await output.send(tuple(i[0] for i in buf))
+                    await output(tuple(i[0] for i in buf))
 
 class Group(Section):
     """Groups received items by time based interval.
@@ -127,9 +127,9 @@ class Group(Section):
                             self._add_item(await receive_channel.receive(), buffer)
                 except trio.EndOfChannel:
                     if buffer:
-                        await output.send(self._process_result(buffer))
+                        await output(self._process_result(buffer))
                     break
-                await output.send(self._process_result(buffer))
+                await output(self._process_result(buffer))
 
     def _add_item(self, item, buffer):
         if self.mapper is not None:
@@ -179,5 +179,5 @@ class Delay(Section):
                 now = trio.current_time()
                 if timestamp > now:
                     await trio.sleep(timestamp - now)
-                await output.send(item)
+                await output(item)
             nursery.cancel_scope.cancel()

--- a/slurry/sections/_filters.py
+++ b/slurry/sections/_filters.py
@@ -33,7 +33,7 @@ class Skip(Section):
             for _ in range(self.count):
                 await aiter.__anext__()
             async for item in aiter:
-                await output.send(item)
+                await output(item)
 
 class Filter(Section):
     """Outputs items that passes a filter function.
@@ -64,7 +64,7 @@ class Filter(Section):
         async with aclosing(source) as aiter:
             async for item in aiter:
                 if self.func(item):
-                    await output.send(item)
+                    await output(item)
 
 class Changes(Section):
     """Outputs items that are different from the last item output.
@@ -100,7 +100,7 @@ class Changes(Section):
             async for item in aiter:
                 if last is token or item != last:
                     last = item
-                    await output.send(item)
+                    await output(item)
 
 class RateLimit(Section):
     """Limits data rate of an input to a certain interval.
@@ -155,4 +155,4 @@ class RateLimit(Section):
                 then = timestamps.get(subject)
                 if then is None or now - then > self.interval:
                     timestamps[subject] = now
-                    await output.send(item)
+                    await output(item)

--- a/slurry/sections/_filters.py
+++ b/slurry/sections/_filters.py
@@ -57,7 +57,7 @@ class Filter(Section):
         if input:
             source = input
         elif self.source:
-             source = self.source
+            source = self.source
         else:
             raise RuntimeError('No input provided.')
 

--- a/slurry/sections/_producers.py
+++ b/slurry/sections/_producers.py
@@ -41,14 +41,14 @@ class Repeat(Section):
                     with cancel_scope:
                         while True:
                             await trio.sleep(self.interval)
-                            await output.send(item)                
+                            await output(item)                
                 nursery.start_soon(repeater)
                 return cancel_scope
 
             previous_repeater = None
 
             if self.has_default:
-                await output.send(self.default)
+                await output(self.default)
                 previous_repeater = start_new_repeater(self.default)
 
             if input:
@@ -56,5 +56,5 @@ class Repeat(Section):
                     async for item in aiter:
                         if previous_repeater:
                             previous_repeater.cancel()
-                        await output.send(item)
+                        await output(item)
                         previous_repeater = start_new_repeater(item)

--- a/slurry/sections/abc.py
+++ b/slurry/sections/abc.py
@@ -2,8 +2,6 @@
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Optional
 
-import trio
-
 class Section(ABC):
     """Each pipeline section takes inputs from an async iterable, processes it and sends it to an
     output.

--- a/slurry/sections/abc.py
+++ b/slurry/sections/abc.py
@@ -1,6 +1,6 @@
 """ Abstract Base Classes for building pipeline sections. """
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterable, Callable, Iterable, Optional
+from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Optional
 
 import trio
 
@@ -13,7 +13,7 @@ class Section(ABC):
     """
 
     @abstractmethod
-    async def pump(self, input: Optional[AsyncIterable[Any]], output: trio.MemorySendChannel):
+    async def pump(self, input: Optional[AsyncIterable[Any]], output: Callable[[Any], Awaitable[None]]):
         """The pump method must contain the logic that iterates the input, processes the indidual
         items, and feeds results to the output.
 
@@ -32,8 +32,8 @@ class Section(ABC):
         :param input: The input data feed. Will be ``None`` for the first ``Section``, as the first
             ``Section`` is expected to supply it's own input.
         :type input: Optional[AsyncIterable[Any]]
-        :param output: The output memory channel where results are sent.
-        :type output: trio.MemorySendChannel
+        :param output: An awaitable callable used to send output.
+        :type output: Callable[[Any], Awaitable[None]]
         """
 
 class ThreadSection(ABC):
@@ -59,7 +59,7 @@ class ThreadSection(ABC):
         :param input: The input data feed. Like with ordinary sections, this can be ``None`` if
             ``ThreadSection`` is the first section in the pipeline.
         :type input: Optional[Iterable[Any]]
-        :param output: The synchronous output send interface.
+        :param output: The callable used to send output.
         :type output: Callable[[Any], None]
         """
 
@@ -90,6 +90,6 @@ class ProcessSection(ABC):
         :param input: The input data feed. Like with ordinary sections, this can be ``None`` if
             ``ProcessSection`` is the first section in the pipeline.
         :type input: Optional[Iterable[Any]]
-        :param output: The synchronous output send interface.
+        :param output: The callable used to send output.
         :type output: Callable[[Any], None]
         """

--- a/slurry/sections/pump.py
+++ b/slurry/sections/pump.py
@@ -15,7 +15,7 @@ async def pump(section, input: Optional[AsyncIterable[Any]], output: trio.Memory
     """
     try:
         if isinstance(section, Section):
-            await section.pump(input, output)
+            await section.pump(input, output.send)
         elif isinstance(section, ThreadSection):
             await _thread_section_pump(section, input, output.send)
         elif isinstance(section, ProcessSection):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -35,7 +35,7 @@ async def test_early_tap_closure_section(autojump_clock):
 
         async def pump(self, input, output):
             for i in range(self.stop):
-                await output.send(i)
+                await output(i)
 
     for _ in range(100):
         async with Pipeline.create(

--- a/tests/test_refiners.py
+++ b/tests/test_refiners.py
@@ -1,5 +1,6 @@
 from slurry import Pipeline
-from slurry.sections import Map
+from slurry.sections import Map, Delay
+import trio
 
 from .fixtures import produce_increasing_integers
 
@@ -9,3 +10,10 @@ async def test_map(autojump_clock):
     ) as pipeline, pipeline.tap() as aiter:
         result = [i async for i in aiter]
         assert result == [0, 1, 4, 9, 16]
+
+async def test_map_section(autojump_clock):
+    async with Pipeline.create(
+        Map(lambda x: x*x, Delay(1, produce_increasing_integers(1, max=5)))
+    ) as pipeline, pipeline.tap() as aiter:
+        result = [(i, trio.current_time()) async for i in aiter]
+        assert result == [(0, 1), (1, 2), (4, 3), (9, 4), (16, 5)]


### PR DESCRIPTION
This reworks the section api to not depend explicitly on trio. Instead of outputs explicitly being `trio.MemorySendChannel`, outputs are now simply a callable that returns an awaitable. Behind the scenes the callable is still the send method of a MemorySendChannel, but in the future, if slurry supports other async loops, the equivalent replacement would be a Queue put method.