### PR TITLE
Add pipeline weld function

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## v0.9.0
+
+* New PipelineSection concept. The pipeline section generalizes the types of input that is allowed in pipelines and select sections that take input. PipelineSections can either be asynchronous iterables, Sections or Tuples representing sequences of pipeline sections. Using tuples of pipeline sections, it possible to compose nested pipelines to any depth.
+* Changed api. Section pumps now take a callable that returns an awaitable as output, instead of an explicit trio.MemorySendChannel. This brings the api in line with synchronous sections, but is obviously a breaking change.
+
 ## v0.8.0
 
 * New ProcessSection abc. Code can now be spawned in a seperate python process, making true concurrency possible!

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,19 @@ Abc
 ---
 .. automodule:: slurry.sections.abc
 
+PipelineSection
+^^^^^^^^^^^^^^^
+
+A ``PipelineSection`` is any object that is valid in the definition of a new a :class:`Pipeline` process.
+This currently includes the following types:
+
+* ``AsyncIterable[Any]`` - Async iterables are valid only as the very first ``PipelineSection``. Subsequent
+  sections will use this async iterable as input source.
+* A :class:`Section`, :class:`ThreadSection` or :class:`ProcessSection`
+* ``Tuple[PipelineSection, ...]`` - Pipeline sections can be nested to any level by supplying a tuple
+  containing one or more PipelineSections. Output from upstream sections are automatically used as input
+  to the nested sequence of pipeline sections.
+
 Section
 ^^^^^^^
 .. autoclass:: Section

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,11 @@ ProcessSection
 .. autoclass:: ProcessSection
   :members:
 
+Weld
+----
+.. automodule:: slurry.sections.weld
+  :members:
+
 Pump
 ----
 .. automodule:: slurry.sections.pump

--- a/slurry/sections/_combiners.py
+++ b/slurry/sections/_combiners.py
@@ -1,12 +1,12 @@
 """Pipeline sections for combining multiple inputs into a single output."""
 import builtins
 import itertools
-from typing import Any, AsyncIterable, Awaitable, Optional, Sequence, Union
+from typing import Any, AsyncIterable, Sequence
 
 import trio
 from async_generator import aclosing
 
-from .abc import Section, ThreadSection, ProcessSection, PipelineSection
+from .abc import Section
 from .weld import weld
 
 class Chain(Section):
@@ -27,7 +27,7 @@ class Chain(Section):
         ``'first'`` (default) \| ``'last'``.
     :type place_input: string
     """
-    def __init__(self, *sources: Sequence[PipelineSection], place_input='first'):
+    def __init__(self, *sources: Sequence["PipelineSection"], place_input='first'):
         super().__init__()
         self.sources = sources
         self.place_input = _validate_place_input(place_input)
@@ -60,7 +60,7 @@ class Merge(Section):
     :param sources: One or more async iterables or sections who's contents will be merged.
     :type sources: Sequence[PipelineSection]
     """
-    def __init__(self, *sources: Sequence[PipelineSection]):
+    def __init__(self, *sources: Sequence["PipelineSection"]):
         super().__init__()
         self.sources = sources
 
@@ -96,7 +96,7 @@ class Zip(Section):
         ``'first'`` (default) \| ``'last'``.
     :type place_input: string
     """
-    def __init__(self, *sources: Sequence[AsyncIterable[Any]], place_input='first'):
+    def __init__(self, *sources: Sequence["PipelineSection"], place_input='first'):
         super().__init__()
         self.sources = sources
         self.place_input = _validate_place_input(place_input)
@@ -165,7 +165,7 @@ class ZipLatest(Section):
         Defaults to ``False``
     :type monitor_input: bool
     """
-    def __init__(self, *sources: Sequence[AsyncIterable[Any]],
+    def __init__(self, *sources: Sequence["PipelineSection"],
                  partial=True,
                  default=None,
                  monitor=(),

--- a/slurry/sections/abc.py
+++ b/slurry/sections/abc.py
@@ -1,6 +1,6 @@
 """ Abstract Base Classes for building pipeline sections. """
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Optional
+from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Optional, Sequence, Tuple, TypeVar
 
 class Section(ABC):
     """Each pipeline section takes inputs from an async iterable, processes it and sends it to an
@@ -91,3 +91,11 @@ class ProcessSection(ABC):
         :param output: The callable used to send output.
         :type output: Callable[[Any], None]
         """
+
+PipelineSection = TypeVar(
+    'PipelineSection',
+    AsyncIterable[Any],
+    Section,
+    ThreadSection,
+    ProcessSection,
+    Tuple["PipelineSection", ...])

--- a/slurry/sections/abc.py
+++ b/slurry/sections/abc.py
@@ -1,6 +1,6 @@
 """ Abstract Base Classes for building pipeline sections. """
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Optional, Sequence, Tuple, TypeVar
+from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Optional
 
 class Section(ABC):
     """Each pipeline section takes inputs from an async iterable, processes it and sends it to an
@@ -91,11 +91,3 @@ class ProcessSection(ABC):
         :param output: The callable used to send output.
         :type output: Callable[[Any], None]
         """
-
-PipelineSection = TypeVar(
-    'PipelineSection',
-    AsyncIterable[Any],
-    Section,
-    ThreadSection,
-    ProcessSection,
-    Tuple["PipelineSection", ...])

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -1,5 +1,5 @@
 """
-The weld module implements the weld function that connects Sections together and
+The weld module implements the weld function that connects pipeline sections together and
 returns the async iterable output.
 """
 
@@ -12,11 +12,13 @@ from .pump import pump
 
 def weld(nursery, *sections: Sequence[PipelineSection]) -> AsyncIterable[Any]:
     """
-    Connects the individual parts of a ``SectionSequence`` together and starts pumps for
+    Connects the individual parts of a sequence of pipeline sections together and starts pumps for
     individual Sections. It returns an async iterable which yields results of the sequence.
 
-    :param :class:`trio.Nursery` nursery: The nursery that runs individual pipeline section pumps.
-    :param SectionSequence sections: A sequence of pipeline sections.
+    :param nursery: The nursery that runs individual pipeline section pumps.
+    :type nursery: :class:`trio.Nursery`
+    :param \*sections: A sequence of pipeline sections.
+    :type \*sections: Sequence[PipelineSection]
     """
     section_input = None
     output = None

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -7,10 +7,10 @@ from typing import Any, AsyncIterable, Sequence
 
 import trio
 
-from .abc import Section, ThreadSection, ProcessSection, PipelineSection
+from .abc import Section, ThreadSection, ProcessSection
 from .pump import pump
 
-def weld(nursery, *sections: Sequence[PipelineSection]) -> AsyncIterable[Any]:
+def weld(nursery, *sections: Sequence["PipelineSection"]) -> AsyncIterable[Any]:
     """
     Connects the individual parts of a sequence of pipeline sections together and starts pumps for
     individual Sections. It returns an async iterable which yields results of the sequence.

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -1,16 +1,27 @@
-from itertools import chain
-from typing import Any, AsyncIterable, Sequence, Union
+"""
+The weld module implements the weld function that connects Sections together and
+returns the async iterable output.
+"""
+
+from typing import Any, AsyncIterable, Sequence, Tuple, Union, NewType
 
 import trio
 
 from .abc import Section, ThreadSection, ProcessSection
 from .pump import pump
 
-def weld(
-    nursery,
-    *sections: Sequence[Union[AsyncIterable[Any], Section, ThreadSection, ProcessSection]]
-    ) -> AsyncIterable[Any]:
+SectionSequence = NewType(
+    'SectionSequence',
+    Sequence[Union[AsyncIterable[Any], Section, ThreadSection, ProcessSection, Tuple]])
 
+def weld(nursery, *sections: SectionSequence) -> AsyncIterable[Any]:
+    """
+    Connects the individual parts of a ``SectionSequence`` together and starts pumps for
+    individual Sections. It returns an async iterable which yields results of the sequence.
+
+    :param :class:`trio.Nursery` nursery: The nursery that runs individual pipeline section pumps.
+    :param SectionSequence sections: A sequence of pipeline sections.
+    """
     section_input = None
     output = None
     for section in sections:

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -3,18 +3,14 @@ The weld module implements the weld function that connects Sections together and
 returns the async iterable output.
 """
 
-from typing import Any, AsyncIterable, Sequence, Tuple, Union, NewType
+from typing import Any, AsyncIterable, Sequence
 
 import trio
 
-from .abc import Section, ThreadSection, ProcessSection
+from .abc import Section, ThreadSection, ProcessSection, PipelineSection
 from .pump import pump
 
-SectionSequence = NewType(
-    'SectionSequence',
-    Sequence[Union[AsyncIterable[Any], Section, ThreadSection, ProcessSection, Tuple]])
-
-def weld(nursery, *sections: SectionSequence) -> AsyncIterable[Any]:
+def weld(nursery, *sections: Sequence[PipelineSection]) -> AsyncIterable[Any]:
     """
     Connects the individual parts of a ``SectionSequence`` together and starts pumps for
     individual Sections. It returns an async iterable which yields results of the sequence.

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -1,0 +1,31 @@
+from itertools import chain
+from typing import Any, AsyncIterable, Sequence, Union
+
+import trio
+
+from .abc import Section, ThreadSection, ProcessSection
+from .pump import pump
+
+def weld(
+    nursery,
+    *sections: Sequence[Union[AsyncIterable[Any], Section, ThreadSection, ProcessSection]]
+    ) -> AsyncIterable[Any]:
+
+    section_input = None
+    output = None
+    for section in sections:
+        if isinstance(section, (Section, ThreadSection, ProcessSection)):
+            section_output, output = trio.open_memory_channel(0)
+            nursery.start_soon(pump, section, section_input, section_output)
+        elif isinstance(section, tuple):
+            if section_input:
+                output = weld(nursery, section_input, *section)
+            else:
+                output = weld(nursery, *section)
+        else:
+            if output:
+                raise ValueError('Invalid pipeline section.', section)
+            output = section
+        section_input = output
+
+    return output

--- a/tests/test_combiners.py
+++ b/tests/test_combiners.py
@@ -1,5 +1,5 @@
 from slurry import Pipeline
-from slurry.sections import Chain, Merge, Zip, ZipLatest, Repeat
+from slurry.sections import Chain, Merge, Zip, ZipLatest, Repeat, Map, Skip
 
 from .fixtures import produce_increasing_integers, produce_alphabet
 
@@ -28,6 +28,20 @@ async def test_merge_section(autojump_clock):
                 break
     assert result == ['a', 0, 'a', 1, 'a', 2]
 
+async def test_merge_pipeline_section(autojump_clock):
+    async with Pipeline.create(
+        Merge(produce_increasing_integers(1, max=3, delay=0.5),
+            (
+                Repeat(1, default='a'),
+                Map(lambda item: item + 'x')
+            ))
+    ) as pipeline, pipeline.tap() as aiter:
+        result = []
+        async for i in aiter:
+            result.append(i)
+            if len(result) == 6:
+                break
+    assert result == ['ax', 0, 'ax', 1, 'ax', 2]
 
 async def test_zip(autojump_clock):
     async with Pipeline.create(
@@ -37,6 +51,21 @@ async def test_zip(autojump_clock):
             results = [item async for item in aiter]
             assert results == [(0,'a'), (1, 'b'), (2, 'c')]
 
+async def test_zip_pipeline_section(autojump_clock):
+    async with Pipeline.create(
+        Zip(
+        (
+            produce_increasing_integers(1, max=5),
+            Skip(2)
+        ),
+        (
+            produce_alphabet(0.9),
+            Map(lambda item: item + 'x')
+        ))
+    ) as pipeline, pipeline.tap() as aiter:
+            results = [item async for item in aiter]
+            assert results == [(2,'ax'), (3, 'bx'), (4, 'cx')]
+
 async def test_zip_latest(autojump_clock):
     async with Pipeline.create(
         ZipLatest(
@@ -45,3 +74,24 @@ async def test_zip_latest(autojump_clock):
     ) as pipeline, pipeline.tap() as aiter:
         result = [item async for item in aiter]
         assert result == [(0, None),  (0, 'a'), (1, 'a'), (1, 'b'), (2, 'b')]
+
+async def test_zip_latest_pipeline_section(autojump_clock):
+    async with Pipeline.create(
+        ZipLatest(
+        (
+            produce_increasing_integers(1, max=5),
+            Skip(2)
+            # t=2: 2
+            # t=3: 3
+            # t=4: 4 (Stops)
+        ),
+        (
+            produce_alphabet(1.3, max=3, delay=0.5),
+            Map(lambda item: item + 'x')
+            # t=0: 'ax'
+            # t=1.8: 'bx'
+            # t=3.1: 'cx' (Stops)
+        ))
+    ) as pipeline, pipeline.tap() as aiter:
+        result = [item async for item in aiter]
+        assert result == [(None, 'ax'),  (None, 'bx'), (2, 'bx'), (3, 'bx'), (3, 'cx')]

--- a/tests/test_refiners.py
+++ b/tests/test_refiners.py
@@ -10,10 +10,3 @@ async def test_map(autojump_clock):
     ) as pipeline, pipeline.tap() as aiter:
         result = [i async for i in aiter]
         assert result == [0, 1, 4, 9, 16]
-
-async def test_map_section(autojump_clock):
-    async with Pipeline.create(
-        Map(lambda x: x*x, Delay(1, produce_increasing_integers(1, max=5)))
-    ) as pipeline, pipeline.tap() as aiter:
-        result = [(i, trio.current_time()) async for i in aiter]
-        assert result == [(0, 1), (1, 2), (4, 3), (9, 4), (16, 5)]


### PR DESCRIPTION
The weld function allows both sections and pipelines to 'weld' sequences of pipeline sections together in a composable fashion.

All combine sections have been modified to add support for this weld function thereby allowing composition of arbitrary sub-pipelines as inputs.