### PR TITLE
Fix typing and a few bugs

### DIFF
--- a/docs/user.rst
+++ b/docs/user.rst
@@ -38,9 +38,9 @@ pipeline out of individual sections. A ``PipelineSection`` is any object that is
 function. This currently includes the following types:
 
 AsyncIterables
-  Async iterables are valid only as the very first ``PipelineSection``. Subsequent
-  sections will use this async iterable as input source. Placing an ``AsyncIterable`` into the middle of
-  a sequence of pipeline sections, will cause a ``ValueError``.
+  Async iterables are valid only as the very first ``PipelineSection``, and must support the ``aclose()``
+  method (nearly all do). Subsequent sections will use this async iterable as input source. Placing an
+  ``AsyncIterable`` into the middle of a sequence of pipeline sections, will cause a ``ValueError``.
 Sections
   Any :class:`Section <slurry.sections.abc.Section>` abc subclass is a valid ``PipelineSection``, at any
   position in the pipeline.

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,17 +26,6 @@ files = [
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
-name = "async-generator"
-version = "1.10"
-description = "Async generators and context managers for Python 3.5+"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
-    {file = "async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"},
-]
-
-[[package]]
 name = "attrs"
 version = "23.2.0"
 description = "Classes Without Boilerplate"
@@ -895,4 +884,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "ca21f6d0cebe7f3af9c74277edf6de1541014df6f1ce1d89df8d8ed167e73d01"
+content-hash = "438477d8aefee8e748be47f77e3fb979322e7773abe5308b8f3b72011f567625"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-async-generator = "^1.10"
 python = "^3.8"
 trio = "^0.23.0"
 

--- a/slurry/__init__.py
+++ b/slurry/__init__.py
@@ -1,4 +1,4 @@
 """An async streaming data processing framework."""
 __version__ = '1.3.1'
 
-from ._pipeline import Pipeline
+from ._pipeline import Pipeline as Pipeline

--- a/slurry/_pipeline.py
+++ b/slurry/_pipeline.py
@@ -5,11 +5,11 @@ from typing import Any, AsyncGenerator
 from contextlib import asynccontextmanager
 
 import trio
-from async_generator import aclosing
 
 from .sections.weld import weld
 from ._tap import Tap
 from ._types import PipelineSection
+from ._utils import aclosing
 
 class Pipeline:
     """The main Slurry ``Pipeline`` class.
@@ -54,7 +54,7 @@ class Pipeline:
             output = weld(nursery, *self.sections)
 
             # Output to taps
-            async with aclosing(output) as aiter:
+            async with aclosing(output.__aiter__()) as aiter:
                 async for item in aiter:
                     self._taps = set(filter(lambda tap: not tap.closed, self._taps))
                     if not self._taps:

--- a/slurry/_types.py
+++ b/slurry/_types.py
@@ -1,4 +1,8 @@
-from typing import Awaitable, Protocol, runtime_checkable
+from typing import Any, AsyncIterable, Awaitable, Protocol, Tuple, Union, runtime_checkable
+
+from .sections.abc import Section
+
+PipelineSection = Union[AsyncIterable[Any], Section, Tuple["PipelineSection", ...]]
 
 @runtime_checkable
 class SupportsAclose(Protocol):

--- a/slurry/_types.py
+++ b/slurry/_types.py
@@ -1,10 +1,20 @@
-from typing import Any, AsyncIterable, Awaitable, Protocol, Tuple, Union, runtime_checkable
+from typing import Any, Awaitable, Protocol, Tuple, TypeVar, Union, runtime_checkable
 
-from .sections.abc import Section
+from .sections import abc
 
-PipelineSection = Union[AsyncIterable[Any], Section, Tuple["PipelineSection", ...]]
+PipelineSection = Union["AsyncIterableWithAcloseableIterator[Any]", "abc.Section", Tuple["PipelineSection", ...]]
+
+_T_co = TypeVar("_T_co", covariant=True)
 
 @runtime_checkable
 class SupportsAclose(Protocol):
-    def aclose(self) -> Awaitable[object]:
-        ...
+    def aclose(self) -> Awaitable[object]: ...
+
+@runtime_checkable
+class AcloseableAsyncIterator(SupportsAclose, Protocol[_T_co]):
+    def __anext__(self) -> Awaitable[_T_co]: ...
+    def __aiter__(self) -> "AcloseableAsyncIterator[_T_co]": ...
+
+@runtime_checkable
+class AsyncIterableWithAcloseableIterator(Protocol[_T_co]):
+    def __aiter__(self) -> AcloseableAsyncIterator[_T_co]: ...

--- a/slurry/_types.py
+++ b/slurry/_types.py
@@ -1,0 +1,6 @@
+from typing import Awaitable, Protocol, runtime_checkable
+
+@runtime_checkable
+class SupportsAclose(Protocol):
+    def aclose(self) -> Awaitable[object]:
+        ...

--- a/slurry/_utils.py
+++ b/slurry/_utils.py
@@ -1,0 +1,15 @@
+from typing import AsyncGenerator, AsyncIterator, TypeVar
+
+from ._types import SupportsAclose
+
+from contextlib import asynccontextmanager
+
+_T = TypeVar("_T")
+
+@asynccontextmanager
+async def safe_aclosing(obj: AsyncIterator[_T]) -> AsyncGenerator[AsyncIterator[_T], None]:
+    try:
+        yield obj
+    finally:
+        if isinstance(obj, SupportsAclose):
+            await obj.aclose()

--- a/slurry/_utils.py
+++ b/slurry/_utils.py
@@ -1,15 +1,14 @@
-from typing import AsyncGenerator, AsyncIterator, TypeVar
+from typing import AsyncGenerator, TypeVar
 
-from ._types import SupportsAclose
+from ._types import AcloseableAsyncIterator
 
 from contextlib import asynccontextmanager
 
 _T = TypeVar("_T")
 
 @asynccontextmanager
-async def safe_aclosing(obj: AsyncIterator[_T]) -> AsyncGenerator[AsyncIterator[_T], None]:
+async def aclosing(obj: AcloseableAsyncIterator[_T]) -> AsyncGenerator[AcloseableAsyncIterator[_T], None]:
     try:
         yield obj
     finally:
-        if isinstance(obj, SupportsAclose):
-            await obj.aclose()
+        await obj.aclose()

--- a/slurry/environments/__init__.py
+++ b/slurry/environments/__init__.py
@@ -1,3 +1,3 @@
-from ._trio import TrioSection
-from ._threading import ThreadSection
-from ._multiprocessing import ProcessSection
+from ._trio import TrioSection as TrioSection
+from ._threading import ThreadSection as ThreadSection
+from ._multiprocessing import ProcessSection as ProcessSection

--- a/slurry/environments/_multiprocessing.py
+++ b/slurry/environments/_multiprocessing.py
@@ -1,11 +1,12 @@
 """Implements a section that runs in an independent python proces."""
 
 from multiprocessing import Process, SimpleQueue
-from typing import AsyncIterable, Any, Awaitable, Callable, Optional, cast
+from typing import Any, Awaitable, Callable, Optional, cast
 
 import trio
 
 from ..sections.abc import SyncSection
+from .._types import AsyncIterableWithAcloseableIterator
 
 class ProcessSection(SyncSection):
     """ProcessSection defines a section interface with a synchronous
@@ -19,7 +20,9 @@ class ProcessSection(SyncSection):
         <https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled>`_.
     """
 
-    async def pump(self, input: Optional[AsyncIterable[Any]], output: Callable[[Any], Awaitable[None]]):
+    async def pump(
+        self, input: Optional[AsyncIterableWithAcloseableIterator[Any]], output: Callable[[Any], Awaitable[None]]
+    ):
         """
         The ``ProcessSection`` pump method works similar to the threaded version, however
         since communication between processes is not as simple as it is between threads,

--- a/slurry/environments/_multiprocessing.py
+++ b/slurry/environments/_multiprocessing.py
@@ -1,7 +1,7 @@
 """Implements a section that runs in an independent python proces."""
 
 from multiprocessing import Process, SimpleQueue
-from typing import Any, Iterable, Callable, cast
+from typing import AsyncIterable, Any, Awaitable, Callable, Optional, cast
 
 import trio
 
@@ -19,7 +19,7 @@ class ProcessSection(SyncSection):
         <https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled>`_.
     """
 
-    async def pump(self, input: Iterable[Any], output: Callable[[Any], None]):
+    async def pump(self, input: Optional[AsyncIterable[Any]], output: Callable[[Any], Awaitable[None]]):
         """
         The ``ProcessSection`` pump method works similar to the threaded version, however
         since communication between processes is not as simple as it is between threads,

--- a/slurry/environments/_threading.py
+++ b/slurry/environments/_threading.py
@@ -1,9 +1,10 @@
 """The threading module implements a synchronous section that runs in a background thread."""
-from typing import Any, AsyncIterable, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 import trio
 
 from ..sections.abc import SyncSection
+from .._types import AsyncIterableWithAcloseableIterator
 
 
 class ThreadSection(SyncSection):
@@ -12,7 +13,7 @@ class ThreadSection(SyncSection):
     """
 
     async def pump(self,
-                   input: Optional[AsyncIterable[Any]],
+                   input: Optional[AsyncIterableWithAcloseableIterator[Any]],
                    output: Callable[[Any], Awaitable[None]]):
         """Runs the refine method in a background thread with synchronous input and output
         wrappers, which transparently bridges the input and outputs between the parent

--- a/slurry/environments/_threading.py
+++ b/slurry/environments/_threading.py
@@ -1,5 +1,5 @@
 """The threading module implements a synchronous section that runs in a background thread."""
-from typing import Any, Iterable, Callable
+from typing import Any, AsyncIterable, Awaitable, Callable, Optional
 
 import trio
 
@@ -12,8 +12,8 @@ class ThreadSection(SyncSection):
     """
 
     async def pump(self,
-                   input: Iterable[Any],
-                   output: Callable[[Any], None]):
+                   input: Optional[AsyncIterable[Any]],
+                   output: Callable[[Any], Awaitable[None]]):
         """Runs the refine method in a background thread with synchronous input and output
         wrappers, which transparently bridges the input and outputs between the parent
         trio event loop and the sync world.

--- a/slurry/environments/_threading.py
+++ b/slurry/environments/_threading.py
@@ -28,9 +28,10 @@ class ThreadSection(SyncSection):
             """Wrapper for turning an async iterable into a blocking generator."""
             if input is None:
                 return
+            input_aiter = input.__aiter__()
             try:
                 while True:
-                    yield trio.from_thread.run(input.__anext__)
+                    yield trio.from_thread.run(input_aiter.__anext__)
             except StopAsyncIteration:
                 pass
 

--- a/slurry/environments/_trio.py
+++ b/slurry/environments/_trio.py
@@ -1,13 +1,16 @@
 """The Trio environment implements ``TrioSection``, which is a Trio-native 
 :class:`AsyncSection <slurry.sections.abc.AsyncSection>`."""
-from typing import Any, AsyncIterable, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from ..sections.abc import AsyncSection
+from .._types import AsyncIterableWithAcloseableIterator
 
 class TrioSection(AsyncSection):
     """Since Trio is the native Slurry event loop, this environment is simple to implement.
     The pump method does not need to do anything special to bridge the input and output. It
     simply delegates directly to the refine method, as the api is identical."""
-    async def pump(self, input: Optional[AsyncIterable[Any]], output: Callable[[Any], Awaitable[None]]):
+    async def pump(
+        self, input: Optional[AsyncIterableWithAcloseableIterator[Any]], output: Callable[[Any], Awaitable[None]]
+    ):
         """Calls refine."""
         await self.refine(input, output)

--- a/slurry/sections/__init__.py
+++ b/slurry/sections/__init__.py
@@ -1,6 +1,6 @@
 """A collection of common stream operations."""
-from ._buffers import Window, Group, Delay
-from ._combiners import Chain, Merge, Zip, ZipLatest
-from ._filters import Skip, SkipWhile, Filter, Changes, RateLimit
-from ._producers import Repeat, Metronome, InsertValue
-from ._refiners import Map
+from ._buffers import Window as Window, Group as Group, Delay as Delay
+from ._combiners import Chain as Chain, Merge as Merge, Zip as Zip, ZipLatest as ZipLatest
+from ._filters import Skip as Skip, SkipWhile as SkipWhile, Filter as Filter, Changes as Changes, RateLimit as RateLimit
+from ._producers import Repeat as Repeat, Metronome as Metronome, InsertValue as InsertValue
+from ._refiners import Map as Map

--- a/slurry/sections/_buffers.py
+++ b/slurry/sections/_buffers.py
@@ -90,13 +90,13 @@ class Group(TrioSection):
     :type reducer: Optional[Callable[[Sequence[Any]], Any]]
     """
     def __init__(self, interval: float, source: Optional[AsyncIterable[Any]] = None, *,
-                 max_size: int = math.inf,
+                 max_size: Optional[int] = None,
                  mapper: Optional[Callable[[Any], Any]] = None,
                  reducer: Optional[Callable[[Sequence[Any]], Any]] = None):
         super().__init__()
         self.source = source
         self.interval = interval
-        self.max_size = max_size
+        self.max_size = math.inf if max_size is None else max_size
         self.mapper = mapper
         self.reducer = reducer
 

--- a/slurry/sections/_combiners.py
+++ b/slurry/sections/_combiners.py
@@ -1,13 +1,13 @@
 """Pipeline sections for combining multiple inputs into a single output."""
 import builtins
 import itertools
-from typing import Any, AsyncIterable, Sequence
 
 import trio
 from async_generator import aclosing
 
 from ..environments import TrioSection
 from .weld import weld
+from .._types import PipelineSection
 
 class Chain(TrioSection):
     """Chains input from one or more sources. Any valid ``PipelineSection`` is an allowed source.
@@ -21,13 +21,11 @@ class Chain(TrioSection):
         By default, the input is added as the first source. If the input is added last instead
         of first, it will cause backpressure to be applied upstream.
 
-    :param sources: One or more ``PipelineSection`` that will be chained together.
-    :type sources: Sequence[PipelineSection]
-    :param place_input: Iteration priority of the pipeline input source. Options:
+    :param PipelineSection \\*sources: One or more ``PipelineSection`` that will be chained together.
+    :param string place_input: Iteration priority of the pipeline input source. Options:
         ``'first'`` (default) \\| ``'last'``.
-    :type place_input: string
     """
-    def __init__(self, *sources: Sequence["PipelineSection"], place_input='first'):
+    def __init__(self, *sources: PipelineSection, place_input='first'):
         super().__init__()
         self.sources = sources
         self.place_input = _validate_place_input(place_input)
@@ -57,10 +55,10 @@ class Merge(TrioSection):
     Sources can be pipeline sections, which will be treated as first sections, with
     no input. Merge will take care of running the pump task for these sections.
 
-    :param sources: One or more async iterables or sections who's contents will be merged.
-    :type sources: Sequence[PipelineSection]
+    :param PipelineSection \\*sources: One or more async iterables or sections whose contents
+        will be merged.
     """
-    def __init__(self, *sources: Sequence["PipelineSection"]):
+    def __init__(self, *sources: PipelineSection):
         super().__init__()
         self.sources = sources
 
@@ -90,13 +88,13 @@ class Zip(TrioSection):
         If sources are out of sync, the fastest source will have to wait for the slowest, which
         will cause backpressure.
 
-    :param sources:  One or more ``PipelineSection``, who's contents will be zipped.
-    :type sources: Sequence[PipelineSection]
+    :param PipelineSection \\*sources:  One or more ``PipelineSection``, whose contents will be
+        zipped.
     :param place_input:  Position of the pipeline input source in the output tuple. Options:
         ``'first'`` (default) \\| ``'last'``.
     :type place_input: string
     """
-    def __init__(self, *sources: Sequence["PipelineSection"], place_input='first'):
+    def __init__(self, *sources: PipelineSection, place_input='first'):
         super().__init__()
         self.sources = sources
         self.place_input = _validate_place_input(place_input)
@@ -145,11 +143,11 @@ class ZipLatest(TrioSection):
     added as an input.
 
     .. Note::
-        If any single source is exchausted, all remaining sources will be forcibly closed, and
+        If any single source is exhausted, all remaining sources will be forcibly closed, and
         the pipeline will stop.
 
-    :param sources: One or more async iterables that will be zipped together.
-    :type sources: Sequence[AsyncIterable[Any]]
+    :param PipelineSection \\*sources: One or more ``PipelineSection`` that will be zipped
+        together.
     :param partial: If ``True`` (default) output will be sent as soon as the first input arrives.
         Otherwise, all main sources must send at least one item, before an output is generated.
     :type partial: bool
@@ -165,7 +163,7 @@ class ZipLatest(TrioSection):
         Defaults to ``False``
     :type monitor_input: bool
     """
-    def __init__(self, *sources: Sequence["PipelineSection"],
+    def __init__(self, *sources: PipelineSection,
                  partial=True,
                  default=None,
                  monitor=(),

--- a/slurry/sections/_filters.py
+++ b/slurry/sections/_filters.py
@@ -29,7 +29,7 @@ class Skip(TrioSection):
         else:
             raise RuntimeError('No input provided.')
 
-        async with aclosing(source) as aiter:
+        async with aclosing(source.__aiter__()) as aiter:
             try:
                 for _ in range(self.count):
                     await aiter.__anext__()

--- a/slurry/sections/_producers.py
+++ b/slurry/sections/_producers.py
@@ -1,11 +1,11 @@
 """Pipeline sections that produce data streams."""
 from time import time
-from typing import Any, AsyncIterable, cast
+from typing import Any
 
 import trio
-from async_generator import aclosing
 
 from ..environments import TrioSection
+from .._utils import aclosing
 
 class Repeat(TrioSection):
     """Yields a single item repeatedly at regular intervals.
@@ -54,7 +54,7 @@ class Repeat(TrioSection):
                 running_repeater = await nursery.start(repeater, self.default)
 
             if input:
-                async with aclosing(input) as aiter:
+                async with aclosing(input.__aiter__()) as aiter:
                     async for item in aiter:
                         if running_repeater:
                             running_repeater.cancel()
@@ -66,7 +66,7 @@ class Metronome(TrioSection):
 
     If used as a middle section, the input can be used to set the value that is sent. When
     an input is received, it is stored and send at the next tick of the clock. If multiple
-    inputs are received during a tick, only the latest is sent. The preceeding inputs are
+    inputs are received during a tick, only the latest is sent. The preceding inputs are
     dropped.
 
     When an input is used, closure of the input stream will cause the metronome to close as well.

--- a/slurry/sections/_producers.py
+++ b/slurry/sections/_producers.py
@@ -127,5 +127,6 @@ class InsertValue(TrioSection):
 
     async def refine(self, input, output):
         await output(self.value)
-        async for item in input:
-            await output(item)
+        if input:
+            async for item in input:
+                await output(item)

--- a/slurry/sections/_producers.py
+++ b/slurry/sections/_producers.py
@@ -94,16 +94,17 @@ class Metronome(TrioSection):
             # pylint: disable=line-too-long
             raise RuntimeError('If Repeat is used as first section,  default value must be provided.')
 
-        input = cast(AsyncIterable[Any], input)
         item = self.default if self.has_default else None
 
         async def pull_task(cancel_scope, *, task_status=trio.TASK_STATUS_IGNORED):
             nonlocal item
-            async for item in input:
-                task_status.started()
-                break
-            async for item in input:
-                pass
+            if input:
+                async for item in input:
+                    break
+            task_status.started()
+            if input:
+                async for item in input:
+                    pass
             cancel_scope.cancel()
 
         async with trio.open_nursery() as nursery:

--- a/slurry/sections/_producers.py
+++ b/slurry/sections/_producers.py
@@ -1,6 +1,6 @@
 """Pipeline sections that produce data streams."""
 from time import time
-from typing import Any
+from typing import Any, AsyncIterable, cast
 
 import trio
 from async_generator import aclosing
@@ -94,6 +94,7 @@ class Metronome(TrioSection):
             # pylint: disable=line-too-long
             raise RuntimeError('If Repeat is used as first section,  default value must be provided.')
 
+        input = cast(AsyncIterable[Any], input)
         item = self.default if self.has_default else None
 
         async def pull_task(cancel_scope, *, task_status=trio.TASK_STATUS_IGNORED):

--- a/slurry/sections/_refiners.py
+++ b/slurry/sections/_refiners.py
@@ -1,8 +1,9 @@
 """Sections for transforming an input into a different output."""
-from typing import Any, AsyncIterable, Optional
+from typing import Any, Optional
 
 from ..environments import TrioSection
-from .._utils import safe_aclosing
+from .._types import AsyncIterableWithAcloseableIterator
+from .._utils import aclosing
 
 class Map(TrioSection):
     """Maps over an asynchronous sequence.
@@ -14,7 +15,7 @@ class Map(TrioSection):
     :param source: Source if used as a starting section.
     :type source: Optional[AsyncIterable[Any]]
     """
-    def __init__(self, func, source: Optional[AsyncIterable[Any]] = None):
+    def __init__(self, func, source: Optional[AsyncIterableWithAcloseableIterator[Any]] = None):
         self.func = func
         self.source = source
 
@@ -26,6 +27,6 @@ class Map(TrioSection):
         else:
             raise RuntimeError('No input provided.')
 
-        async with safe_aclosing(source.__aiter__()) as aiter:
+        async with aclosing(source.__aiter__()) as aiter:
             async for item in aiter:
                 await output(self.func(item))

--- a/slurry/sections/_refiners.py
+++ b/slurry/sections/_refiners.py
@@ -1,9 +1,8 @@
 """Sections for transforming an input into a different output."""
 from typing import Any, AsyncIterable, Optional
 
-from async_generator import aclosing
-
 from ..environments import TrioSection
+from .._utils import safe_aclosing
 
 class Map(TrioSection):
     """Maps over an asynchronous sequence.
@@ -27,6 +26,6 @@ class Map(TrioSection):
         else:
             raise RuntimeError('No input provided.')
 
-        async with aclosing(source) as aiter:
+        async with safe_aclosing(source.__aiter__()) as aiter:
             async for item in aiter:
                 await output(self.func(item))

--- a/slurry/sections/abc.py
+++ b/slurry/sections/abc.py
@@ -1,12 +1,16 @@
 """ Abstract Base Classes for building pipeline sections. """
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Optional
+from typing import Any, Awaitable, Callable, Iterable, Optional
+
+from .._types import AsyncIterableWithAcloseableIterator
 
 class Section(ABC):
     """Defines the basic environment api."""
 
     @abstractmethod
-    async def pump(self, input: Optional[AsyncIterable[Any]], output: Callable[[Any], Awaitable[None]]):
+    async def pump(
+        self, input: Optional[AsyncIterableWithAcloseableIterator[Any]], output: Callable[[Any], Awaitable[None]]
+    ):
         """The pump method contains the machinery that takes input from previous sections, or
         any asynchronous iterable, processes it and pushes it to the output.
 
@@ -16,7 +20,7 @@ class Section(ABC):
 
         :param input: The input data feed. Will be ``None`` for the first ``Section``, as the first
             ``Section`` is expected to supply it's own input.
-        :type input: Optional[AsyncIterable[Any]]
+        :type input: Optional[AsyncIterableWithAcloseableIterator[Any]]
         :param output: An awaitable callable used to send output.
         :type output: Callable[[Any], Awaitable[None]]
         """
@@ -25,13 +29,15 @@ class AsyncSection(Section):
     """AsyncSection defines an abc for sections that are designed to run in an async event loop."""
 
     @abstractmethod
-    async def refine(self, input: Optional[AsyncIterable[Any]], output: Callable[[Any], Awaitable[None]]):
+    async def refine(
+        self, input: Optional[AsyncIterableWithAcloseableIterator[Any]], output: Callable[[Any], Awaitable[None]]
+    ):
         """The async section refine method must contain the logic that iterates the input, processes
         the indidual items, and feeds results to the output.
 
         :param input: The input data feed. Will be ``None`` for the first ``Section``, as the first
             ``Section`` is expected to supply it's own input.
-        :type input: Optional[AsyncIterable[Any]]
+        :type input: Optional[AsyncIterableWithAcloseableIterator[Any]]
         :param output: An awaitable callable used to send output.
         :type output: Callable[[Any], Awaitable[None]]
         """

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -1,13 +1,13 @@
 """Contains the `weld` utility function for composing sections."""
 
-from typing import Any, AsyncIterable, Optional, cast
+from typing import Any, Optional, cast
 
 import trio
 
 from .abc import Section
-from .._types import PipelineSection, SupportsAclose
+from .._types import PipelineSection, AsyncIterableWithAcloseableIterator, SupportsAclose
 
-def weld(nursery, *sections: PipelineSection) -> AsyncIterable[Any]:
+def weld(nursery, *sections: PipelineSection) -> AsyncIterableWithAcloseableIterator[Any]:
     """
     Connects the individual parts of a sequence of pipeline sections together and starts pumps for
     individual Sections. It returns an async iterable which yields results of the sequence.
@@ -17,7 +17,7 @@ def weld(nursery, *sections: PipelineSection) -> AsyncIterable[Any]:
     :param PipelineSection \\*sections: Pipeline sections.
     """
 
-    async def pump(section, input: Optional[AsyncIterable[Any]], output: trio.MemorySendChannel):
+    async def pump(section, input: Optional[AsyncIterableWithAcloseableIterator[Any]], output: trio.MemorySendChannel):
         try:
             await section.pump(input, output.send)
         except trio.BrokenResourceError:
@@ -43,4 +43,4 @@ def weld(nursery, *sections: PipelineSection) -> AsyncIterable[Any]:
             output = section
         section_input = output
 
-    return cast(AsyncIterable[Any], output)
+    return cast(AsyncIterableWithAcloseableIterator[Any], output)

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterable, Optional, Sequence
 import trio
 
 from .abc import Section
+from .._types import SupportsAclose
 
 def weld(nursery, *sections: Sequence["PipelineSection"]) -> AsyncIterable[Any]:
     """
@@ -22,7 +23,7 @@ def weld(nursery, *sections: Sequence["PipelineSection"]) -> AsyncIterable[Any]:
             await section.pump(input, output.send)
         except trio.BrokenResourceError:
             pass
-        if input:
+        if input and isinstance(input, SupportsAclose):
             await input.aclose()
         await output.aclose()
 

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -1,21 +1,20 @@
 """Contains the `weld` utility function for composing sections."""
 
-from typing import Any, AsyncIterable, Optional, Sequence
+from typing import Any, AsyncIterable, Optional, cast
 
 import trio
 
 from .abc import Section
-from .._types import SupportsAclose
+from .._types import PipelineSection, SupportsAclose
 
-def weld(nursery, *sections: Sequence["PipelineSection"]) -> AsyncIterable[Any]:
+def weld(nursery, *sections: PipelineSection) -> AsyncIterable[Any]:
     """
     Connects the individual parts of a sequence of pipeline sections together and starts pumps for
     individual Sections. It returns an async iterable which yields results of the sequence.
 
     :param nursery: The nursery that runs individual pipeline section pumps.
     :type nursery: :class:`trio.Nursery`
-    :param \\*sections: A sequence of pipeline sections.
-    :type \\*sections: Sequence[PipelineSection]
+    :param PipelineSection \\*sections: Pipeline sections.
     """
 
     async def pump(section, input: Optional[AsyncIterable[Any]], output: trio.MemorySendChannel):
@@ -44,4 +43,4 @@ def weld(nursery, *sections: Sequence["PipelineSection"]) -> AsyncIterable[Any]:
             output = section
         section_input = output
 
-    return output
+    return cast(AsyncIterable[Any], output)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -86,18 +86,3 @@ class AsyncNonIteratorIterable:
 
     def __aiter__(self):
         return self.source_aiterable.__aiter__()
-
-class AsyncIteratorWithoutAclose:
-    def __init__(self, source_aiterable):
-        self.source_aiter = source_aiterable.__aiter__()
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        try:
-            return await self.source_aiter.__anext__()
-        except StopAsyncIteration:
-            if hasattr(self.source_aiter, "aclose"):
-                await self.source_aiter.aclose()
-            raise

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -86,3 +86,18 @@ class AsyncNonIteratorIterable:
 
     def __aiter__(self):
         return self.source_aiterable.__aiter__()
+
+class AsyncIteratorWithoutAclose:
+    def __init__(self, source_aiterable):
+        self.source_aiter = source_aiterable.__aiter__()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return await self.source_aiter.__anext__()
+        except StopAsyncIteration:
+            if hasattr(self.source_aiter, "aclose"):
+                await self.source_aiter.aclose()
+            raise

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -79,3 +79,10 @@ class FibonacciSection(ProcessSection):
     def refine(self, input: Iterable[Any], output: Callable[[Any], None]):
         for i in range(self.i):
             output(self.fibonacci(i))
+
+class AsyncNonIteratorIterable:
+    def __init__(self, source_aiterable):
+        self.source_aiterable = source_aiterable
+
+    def __aiter__(self):
+        return self.source_aiterable.__aiter__()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,11 +1,18 @@
 from slurry import Pipeline
 from slurry.sections import Merge, RateLimit, Skip, SkipWhile, Filter, Changes
 
-from .fixtures import produce_increasing_integers, produce_mappings
+from .fixtures import AsyncNonIteratorIterable, produce_increasing_integers, produce_mappings
 
 async def test_skip(autojump_clock):
     async with Pipeline.create(
         Skip(5, produce_increasing_integers(1, max=10))
+    ) as pipeline, pipeline.tap() as aiter:
+        result = [i async for i in aiter]
+        assert result == [5, 6, 7, 8, 9]
+
+async def test_skip_input_non_iterator_iterable(autojump_clock):
+    async with Pipeline.create(
+            Skip(5, AsyncNonIteratorIterable(produce_increasing_integers(1, max=10)))
     ) as pipeline, pipeline.tap() as aiter:
         result = [i async for i in aiter]
         assert result == [5, 6, 7, 8, 9]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,7 +5,7 @@ from slurry import Pipeline
 from slurry.sections import Map
 from slurry.environments import TrioSection
 
-from .fixtures import AsyncIteratorWithoutAclose, produce_increasing_integers
+from .fixtures import produce_increasing_integers
 
 async def test_pipeline_create(autojump_clock):
     async with Pipeline.create(None):
@@ -47,20 +47,14 @@ async def test_early_tap_closure_section(autojump_clock):
                 assert isinstance(i, int)
                 break
 
-async def perform_welding(source):
+async def test_welding(autojump_clock):
     async with Pipeline.create(
-            source,
-            (Map(lambda i: i+1),)
+        produce_increasing_integers(1),
+        (Map(lambda i: i+1),)
     ) as pipeline:
         async with pipeline.tap() as aiter:
             result = [i async for i in aiter]
             assert result == [1, 2, 3]
-
-async def test_welding(autojump_clock):
-    await perform_welding(produce_increasing_integers(1))
-
-async def test_welding_with_source_no_aclose(autojump_clock):
-    await perform_welding(AsyncIteratorWithoutAclose(produce_increasing_integers(1)))
 
 async def test_welding_two_generator_functions_not_allowed(autojump_clock):
     with pytest.raises(ValueError):

--- a/tests/test_producers.py
+++ b/tests/test_producers.py
@@ -73,3 +73,10 @@ async def test_insert_value(autojump_clock):
         start_time = trio.current_time()
         results = [(v, trio.current_time() - start_time) async for v in aiter]
         assert results == [('n', 0), ('a', 1), ('b', 2), ('c', 3)]
+
+async def test_insert_value_no_input(autojump_clock):
+    async with Pipeline.create(
+            InsertValue('n')
+    ) as pipeline, pipeline.tap() as aiter:
+        results = [v async for v in aiter]
+        assert results == ['n']

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -2,11 +2,19 @@ import pytest
 from slurry import Pipeline
 from slurry.sections import Map
 
-from .fixtures import produce_increasing_integers, SyncSquares
+from .fixtures import AsyncNonIteratorIterable, produce_increasing_integers, SyncSquares
 
 async def test_thread_section(autojump_clock):
     async with Pipeline.create(
         produce_increasing_integers(1, max=5),
+        SyncSquares()
+    ) as pipeline, pipeline.tap() as aiter:
+        result = [i async for i in aiter]
+        assert result == [0, 1, 4, 9, 16]
+
+async def test_thread_section_input_non_iterator_iterable(autojump_clock):
+    async with Pipeline.create(
+        AsyncNonIteratorIterable(produce_increasing_integers(1, max=5)),
         SyncSquares()
     ) as pipeline, pipeline.tap() as aiter:
         result = [i async for i in aiter]


### PR DESCRIPTION
I needed type annotations for Slurry to make the type checks in my own project happy. I'd been using my own type stubs for a couple of days, but thought I'd contribute back.

These typing fixes include a few that were tripping up my thing plus everything reported by Pyright in standard mode (only with `slurry/`, not the tests). A few of the issues noticed by Pyright were actually bugs, so I took the liberty of fixing those, as well. See commit messages for more info.

A couple of things I _didn't_ do, but I'd be happy to if you're open to it. They're actually kinda related and I'd like to do both:
1. ~I spotted a (rare) bug that Pyright didn't explicitly warn about: `aclosing()` is used in many places on async iterators, but not all async iterators have an `aclose()` method. This will error if someone passes a source that doesn't. This is admittedly unusual because they're almost always from generator functions or comprehensions (and more importantly this is the case for memory receive channels, which covers 99% of the time), but it's a non-zero chance kind of problem. I would fix it by creating a `safe_aclosing()` context manager to replace `aclosing()`. It would have no dependency on `aclosing()`, which has the side benefit that the `async_generator` package dependency would no longer be needed at all. That would be good because...~ - Edit: ended up fixing in later commits
2. Fix all typing issues reported by Pyright in _strict_ mode. ~There are many errors right now, mostly coming from the fact that the `async_generator` package is untyped (and there are no type stubs available for it). It's only used for `aclosing()`, which is just a few lines anyway.~ - Edit: ended up fixing in later commits

Edit: Oh, and another rare bug I didn't fix:
3. ~sources are (async-)iterated directly in many places, but they typed as _iterables_, not _iterators_. This isn't usually a problem because _most_ iterables act as their own iterators, but not all. Iteration (with or without `aclose()` wrapping it) will error in those cases. If the typing claims `AsyncIterable`, then _any_ `AsyncIterable` should be supported.~ - Edit: ended up fixing in later commits
 
Btw, I suspect that fixing the lack of typing on `aclose()` mentioned in item 2 would result in Pyright properly warning about both of the bugs. In any case, they're not regressions, and as I said, quite rare to strike anyway. IMO they don't need to hold up a release or anything.