### PR TITLE
Fix risky uses of `__anext__()`

### DIFF
--- a/slurry/environments/_threading.py
+++ b/slurry/environments/_threading.py
@@ -28,9 +28,10 @@ class ThreadSection(SyncSection):
             """Wrapper for turning an async iterable into a blocking generator."""
             if input is None:
                 return
+            input_aiter = input.__aiter__()
             try:
                 while True:
-                    yield trio.from_thread.run(input.__anext__)
+                    yield trio.from_thread.run(input_aiter.__anext__)
             except StopAsyncIteration:
                 pass
 

--- a/slurry/sections/_filters.py
+++ b/slurry/sections/_filters.py
@@ -29,7 +29,7 @@ class Skip(TrioSection):
         else:
             raise RuntimeError('No input provided.')
 
-        async with aclosing(source) as aiter:
+        async with aclosing(source.__aiter__()) as aiter:
             try:
                 for _ in range(self.count):
                     await aiter.__anext__()

--- a/slurry/sections/weld.py
+++ b/slurry/sections/weld.py
@@ -21,7 +21,7 @@ def weld(nursery, *sections: PipelineSection) -> AsyncIterable[Any]:
             await section.pump(input, output.send)
         except trio.BrokenResourceError:
             pass
-        if input:
+        if input and hasattr(input, "aclose") and callable(input.aclose):
             await input.aclose()
         await output.aclose()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -79,3 +79,10 @@ class FibonacciSection(ProcessSection):
     def refine(self, input: Iterable[Any], output: Callable[[Any], None]):
         for i in range(self.i):
             output(self.fibonacci(i))
+
+class AsyncNonIteratorIterable:
+    def __init__(self, source_aiterable):
+        self.source_aiterable = source_aiterable
+
+    def __aiter__(self):
+        return self.source_aiterable.__aiter__()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,11 +1,18 @@
 from slurry import Pipeline
 from slurry.sections import Merge, RateLimit, Skip, SkipWhile, Filter, Changes
 
-from .fixtures import produce_increasing_integers, produce_mappings
+from .fixtures import AsyncNonIteratorIterable, produce_increasing_integers, produce_mappings
 
 async def test_skip(autojump_clock):
     async with Pipeline.create(
         Skip(5, produce_increasing_integers(1, max=10))
+    ) as pipeline, pipeline.tap() as aiter:
+        result = [i async for i in aiter]
+        assert result == [5, 6, 7, 8, 9]
+
+async def test_skip_input_non_iterator_iterable(autojump_clock):
+    async with Pipeline.create(
+            Skip(5, AsyncNonIteratorIterable(produce_increasing_integers(1, max=10)))
     ) as pipeline, pipeline.tap() as aiter:
         result = [i async for i in aiter]
         assert result == [5, 6, 7, 8, 9]

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -2,11 +2,19 @@ import pytest
 from slurry import Pipeline
 from slurry.sections import Map
 
-from .fixtures import produce_increasing_integers, SyncSquares
+from .fixtures import AsyncNonIteratorIterable, produce_increasing_integers, SyncSquares
 
 async def test_thread_section(autojump_clock):
     async with Pipeline.create(
         produce_increasing_integers(1, max=5),
+        SyncSquares()
+    ) as pipeline, pipeline.tap() as aiter:
+        result = [i async for i in aiter]
+        assert result == [0, 1, 4, 9, 16]
+
+async def test_thread_section_input_non_iterator_iterable(autojump_clock):
+    async with Pipeline.create(
+        AsyncNonIteratorIterable(produce_increasing_integers(1, max=5)),
         SyncSquares()
     ) as pipeline, pipeline.tap() as aiter:
         result = [i async for i in aiter]


### PR DESCRIPTION
Calling `__anext__()` on an async iterable is dangerous, because not all iterables act as their own iterators, so may not have that method. These changes ensure that those calls explicitly get an iterator first (by calling `__aiter__()`).
Note: `__aiter__()` is called implicitly in `async for` constructs, so they don't have this risk.